### PR TITLE
feat: Rediseñar navegación del catálogo con pantalla dedicada

### DIFF
--- a/app/src/main/java/com/example/huerto_hogar/AppScreens/AppScreens.kt
+++ b/app/src/main/java/com/example/huerto_hogar/AppScreens/AppScreens.kt
@@ -11,6 +11,8 @@ sealed class AppScreens(val route: String) {
     object VerdurasScreen: AppScreens(route = "verduras_screen")
     object FrutasScreen: AppScreens(route = "frutas_screen")
     object OrganicosScreen: AppScreens(route = "organicos_screen")
+    object CatalogoScreen: AppScreens(route = "catalogo_screen")
+    object AllProductsScreen: AppScreens(route = "all_products_screen")
     
     // Admin routes
     object AdminDashboardScreen: AppScreens(route = "admin_dashboard_screen")

--- a/app/src/main/java/com/example/huerto_hogar/screen/AllProductsScreen.kt
+++ b/app/src/main/java/com/example/huerto_hogar/screen/AllProductsScreen.kt
@@ -1,0 +1,112 @@
+package com.example.huerto_hogar.screen
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import com.example.huerto_hogar.R
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import com.example.huerto_hogar.ui.theme.Huerto_HogarTheme
+import com.example.huerto_hogar.ui.theme.components.Header
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.filled.ShoppingCart
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import com.example.huerto_hogar.model.Product
+import com.example.huerto_hogar.model.ProductCategory
+import com.example.huerto_hogar.model.MockProducts
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.huerto_hogar.viewmodel.CartViewModel
+import kotlinx.coroutines.launch
+
+@Composable
+fun AllProductsScreen(
+    navController: NavHostController,
+    cartViewModel: CartViewModel = viewModel()
+) {
+    // Mostrar todos los productos sin filtrar
+    val allProducts = remember {
+        MockProducts.products
+    }
+    
+    val snackbarHostState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
+
+    Scaffold(
+        topBar = {
+            Header(
+                navController = navController,
+                title = "Todos los Productos"
+            )
+        },
+        snackbarHost = { SnackbarHost(snackbarHostState) }
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp)
+        ) {
+            items(
+                allProducts,
+                key = { it.id }
+            ) { producto ->
+                ProductoCard(
+                    producto = producto,
+                    onAgregarCarrito = { productoAgregado ->
+                        cartViewModel.addToCart(productoAgregado)
+                        coroutineScope.launch {
+                            snackbarHostState.showSnackbar(
+                                message = "✓ ${productoAgregado.name} agregado al carrito",
+                                duration = SnackbarDuration.Short
+                            )
+                        }
+                    }
+                )
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun AllProductsScreenPreview() {
+    Huerto_HogarTheme {
+        val navController = rememberNavController()
+        AllProductsScreen(navController = navController)
+    }
+}

--- a/app/src/main/java/com/example/huerto_hogar/screen/CatalogoScreen.kt
+++ b/app/src/main/java/com/example/huerto_hogar/screen/CatalogoScreen.kt
@@ -1,0 +1,100 @@
+package com.example.huerto_hogar.screen
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.rememberNavController
+import com.example.huerto_hogar.AppScreens.AppScreens
+import com.example.huerto_hogar.R
+import com.example.huerto_hogar.ui.theme.Huerto_HogarTheme
+import com.example.huerto_hogar.ui.theme.components.CategoryButton
+import com.example.huerto_hogar.ui.theme.components.Header
+
+/**
+ * Pantalla principal del catálogo que muestra botones para navegar
+ * a las diferentes categorías de productos
+ */
+@Composable
+fun CatalogoScreen(
+    navController: NavHostController
+) {
+    Scaffold(
+        topBar = {
+            Header(
+                navController = navController,
+                title = "Catálogo"
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(vertical = 8.dp)
+        ) {
+            // Botón Verduras
+            CategoryButton(
+                text = "Verduras",
+                imageRes = R.drawable.zanahorias,
+                onClick = {
+                    navController.navigate(AppScreens.VerdurasScreen.route)
+                },
+                modifier = Modifier.weight(1f)
+            )
+            
+            Spacer(modifier = Modifier.height(8.dp))
+            
+            // Botón Frutas
+            CategoryButton(
+                text = "Frutas",
+                imageRes = R.drawable.manzana_fuji,
+                onClick = {
+                    navController.navigate(AppScreens.FrutasScreen.route)
+                },
+                modifier = Modifier.weight(1f)
+            )
+            
+            Spacer(modifier = Modifier.height(8.dp))
+            
+            // Botón Orgánicos
+            CategoryButton(
+                text = "Orgánicos",
+                imageRes = R.drawable.espinaca,
+                onClick = {
+                    navController.navigate(AppScreens.OrganicosScreen.route)
+                },
+                modifier = Modifier.weight(1f)
+            )
+            
+            Spacer(modifier = Modifier.height(8.dp))
+            
+            // Botón Todos los Productos
+            CategoryButton(
+                text = "Todos los Productos",
+                imageRes = R.drawable.naranja_valencia,
+                onClick = {
+                    navController.navigate(AppScreens.AllProductsScreen.route)
+                },
+                modifier = Modifier.weight(1f)
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun CatalogoScreenPreview() {
+    Huerto_HogarTheme {
+        val navController = rememberNavController()
+        CatalogoScreen(navController = navController)
+    }
+}

--- a/app/src/main/java/com/example/huerto_hogar/ui/theme/components/AppNavigationContainer.kt
+++ b/app/src/main/java/com/example/huerto_hogar/ui/theme/components/AppNavigationContainer.kt
@@ -41,8 +41,10 @@ import com.example.huerto_hogar.AppScreens.AppScreens
 import com.example.huerto_hogar.R
 import com.example.huerto_hogar.manager.UserManagerViewModel
 import com.example.huerto_hogar.model.Role
+import com.example.huerto_hogar.screen.AllProductsScreen
 import com.example.huerto_hogar.screen.BlogScreen
 import com.example.huerto_hogar.screen.CartScreen
+import com.example.huerto_hogar.screen.CatalogoScreen
 import com.example.huerto_hogar.screen.FavScreen
 import com.example.huerto_hogar.screen.FrutasScreen
 import com.example.huerto_hogar.screen.HomeScreen
@@ -83,7 +85,6 @@ fun AppNavigationContainer() {
     }
 
     val drawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
-    val showBarraCatalogo = remember { mutableStateOf(false) }
     var showLogoutDialog by remember { mutableStateOf(false) }
 
     val scope = rememberCoroutineScope()
@@ -243,18 +244,12 @@ fun AppNavigationContainer() {
         Scaffold(
             // Menu de navegacion inferioor
             bottomBar = {
-                Column {
-                    if (showBarraCatalogo.value) {
-                        CatalogoNavigation(
-                            navController = navController,
-                            onCloseMenu = { showBarraCatalogo.value = false })
-                    }
-                    MainBottomBar(navController = navController, onMenuClick = {
+                MainBottomBar(
+                    navController = navController, 
+                    onMenuClick = {
                         scope.launch { drawerState.open() }
-                    }, onCatalogoClick = {
-                        showBarraCatalogo.value = !showBarraCatalogo.value
-                    })
-                }
+                    }
+                )
             }) { contentPadding ->
             // La logica del router/enrutamiento
             NavHost(
@@ -355,6 +350,25 @@ fun AppNavigationContainer() {
                     exitTransition = { fadeOut() }
                 ) { 
                     VerdurasScreen(
+                        navController = navController,
+                        cartViewModel = cartViewModel
+                    ) 
+                }
+                
+                composable(
+                    route = AppScreens.CatalogoScreen.route,
+                    enterTransition = { fadeIn() },
+                    exitTransition = { fadeOut() }
+                ) { 
+                    CatalogoScreen(navController = navController) 
+                }
+                
+                composable(
+                    route = AppScreens.AllProductsScreen.route,
+                    enterTransition = { fadeIn() },
+                    exitTransition = { fadeOut() }
+                ) { 
+                    AllProductsScreen(
                         navController = navController,
                         cartViewModel = cartViewModel
                     ) 

--- a/app/src/main/java/com/example/huerto_hogar/ui/theme/components/CategoryButton.kt
+++ b/app/src/main/java/com/example/huerto_hogar/ui/theme/components/CategoryButton.kt
@@ -1,0 +1,111 @@
+package com.example.huerto_hogar.ui.theme.components
+
+import androidx.annotation.DrawableRes
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.huerto_hogar.R
+import com.example.huerto_hogar.ui.theme.Huerto_HogarTheme
+import com.example.huerto_hogar.ui.theme.components.animations.pressClickEffect
+
+/**
+ * Botón de categoría reutilizable con imagen de fondo y efecto de animación
+ * @param text Texto a mostrar en el botón
+ * @param imageRes ID del recurso drawable de la imagen de fondo
+ * @param onClick Acción al hacer clic en el botón
+ * @param modifier Modificador opcional para personalizar el componente
+ */
+@Composable
+fun CategoryButton(
+    text: String,
+    @DrawableRes imageRes: Int,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+            .pressClickEffect()
+            .clickable(onClick = onClick),
+        shape = RoundedCornerShape(16.dp),
+        elevation = CardDefaults.cardElevation(
+            defaultElevation = 6.dp,
+            pressedElevation = 2.dp
+        )
+    ) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            // Imagen de fondo con transparencia
+            Image(
+                painter = painterResource(id = imageRes),
+                contentDescription = text,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .alpha(0.85f), // Transparencia ligera
+                contentScale = ContentScale.Crop
+            )
+            
+            // Overlay oscuro para mejorar legibilidad del texto
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .alpha(0.4f)
+            ) {
+                androidx.compose.foundation.Canvas(
+                    modifier = Modifier.fillMaxSize()
+                ) {
+                    drawRect(color = Color.Black)
+                }
+            }
+            
+            // Texto sobre la imagen
+            Text(
+                text = text,
+                style = MaterialTheme.typography.headlineSmall.copy(
+                    fontSize = 24.sp,
+                    fontWeight = FontWeight.Bold
+                ),
+                color = Color.White,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.padding(16.dp)
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun CategoryButtonPreview() {
+    Huerto_HogarTheme {
+        CategoryButton(
+            text = "Verduras",
+            imageRes = R.drawable.zanahorias,
+            onClick = {}
+        )
+    }
+}

--- a/app/src/main/java/com/example/huerto_hogar/ui/theme/components/MainBottomBar.kt
+++ b/app/src/main/java/com/example/huerto_hogar/ui/theme/components/MainBottomBar.kt
@@ -25,8 +25,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 @Composable
 fun MainBottomBar(
     navController: NavHostController,
-    onMenuClick: () -> Unit,
-    onCatalogoClick: () -> Unit
+    onMenuClick: () -> Unit
 ) {
     val currentRoute = navController.currentBackStackEntryAsState().value?.destination?.route
 
@@ -56,7 +55,6 @@ fun MainBottomBar(
                             if (destination.route == null) {
                                 when (destination) {
                                     BottomNavViews.MENU -> onMenuClick()
-                                    BottomNavViews.CATALOGO -> onCatalogoClick()
                                     else -> {}
                                 }
                             } else {

--- a/app/src/main/java/com/example/huerto_hogar/ui/theme/components/NavBar.kt
+++ b/app/src/main/java/com/example/huerto_hogar/ui/theme/components/NavBar.kt
@@ -21,6 +21,6 @@ enum class BottomNavViews(
     HOME(AppScreens.HomeScreen.route, Icons.Default.Home,"Home", "Home"),
     FAVORITOS(AppScreens.FavScreen.route, Icons.Default.Favorite, "Favoritos", "Favoritos"),
     CARRITO(AppScreens.CartScreen.route, Icons.Default.ShoppingCart, "Carrito", "Carrito"),
-    CATALOGO(null, Icons.Default.Search, "Catálogo", "Catálogo"),
+    CATALOGO(AppScreens.CatalogoScreen.route, Icons.Default.Search, "Catálogo", "Catálogo"),
     MENU(null, Icons.Default.Menu, "Menú", "Menú")
 }


### PR DESCRIPTION
- Eliminar menú desplegable de categorías (CatalogoNavigation)
- Crear nueva pantalla CatalogoScreen con 4 botones de categoría
- Agregar pantalla AllProductsScreen para mostrar todos los productos
- Crear componente reutilizable CategoryButton con:
  * Imagen de fondo con transparencia (alpha 0.85)
  * Animación pressClickEffect
  * Distribución equitativa del espacio vertical (weight)
  * Overlay oscuro para mejorar legibilidad del texto
- Actualizar MainBottomBar para navegar directamente a CatalogoScreen
- Actualizar AppNavigationContainer eliminando lógica del dropdown
- Agregar rutas CatalogoScreen y AllProductsScreen en AppScreens
- Modificar BottomNavViews para incluir ruta de catálogo